### PR TITLE
dismisses 'About' dialog on escape press

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -118,6 +118,13 @@ $(document).ready(function () {
 	} else {
 		enableLightMode()
 	}
+
+	document.onkeydown = function(evt) {
+		evt = evt || window.event;
+		if (evt.key == 'Escape') {
+			$('#myModal').modal('hide');
+		}
+	};
 });
 
 function debounce(func, wait, immediate) {


### PR DESCRIPTION
Pressing the escape key when the 'About' dialog is open. No errors are thrown when the key is pressed but the dialog is not open