### PR TITLE
Update case-converter/index.html to improve Title Case conversion

### DIFF
--- a/case-converter/index.html
+++ b/case-converter/index.html
@@ -169,11 +169,14 @@
                     ).join('');
                     break;
                 case 'title':
-                    const smallWords = ['a', 'an', 'the', 'and', 'or', 'but', 'in', 'on', 'of'];
+                    const smallWords = ['a', 'an', 'the', 'and', 
+                                        'or', 'nor', 'but', 'in', 
+                                        'on', 'at', 'of', 'for', 
+                                        'by', 'to', 'with'];
                     const paragraphsTitle = inputText.value.split('\n').map(paragraph => {
-                        return paragraph.split(' ').map((word, index) => {
+                        return paragraph.trim().split(' ').map((word, index) => {
                             const lowerCaseWord = word.toLowerCase();
-                            if (index === 0 || index === paragraph.split(' ').length - 1 || !smallWords.includes(lowerCaseWord)) {
+                            if (index === 0 || index === paragraph.trim().split(' ').length - 1 || !smallWords.includes(lowerCaseWord)) {
                                 return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
                             }
                             return lowerCaseWord;


### PR DESCRIPTION
The following changes have been made in case-converter/index.html for issue #57:

1. Include a more comprehensive set of small words that should not be capitalized in the title
2. Trim the leading and trailing spaces of a line before the case conversion for accurate conversion of the first and last word in title