### PR TITLE
Restore standard Ctrl + Delete behavior and move clear note shortcut to Ctrl + Shift + Delete

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -193,6 +193,8 @@ table tr td {
   display: flex;
   align-items: center;
   gap: 2px;
+  flex-wrap: wrap;
+  row-gap: 8px;
 }
 
 .about-icon-container {

--- a/index.html
+++ b/index.html
@@ -1066,7 +1066,7 @@
               <td>Save notes as PDF</td>
             </tr>
             <tr>
-              <td><kbd>ctrl</kbd> / <kbd><span>⌘</span>command</kbd> + <kbd>delete</kbd></td>
+              <td><kbd>ctrl</kbd> + <kbd>shift</kbd> / <kbd><span>⌘</span>command</kbd> + <kbd>delete</kbd></td>
               <td>Delete notes</td>
             </tr>
             <tr>

--- a/js/app.js
+++ b/js/app.js
@@ -1456,7 +1456,7 @@ you can buy me a coffee — the link of which is available in the About section.
 			copyNotesToClipboard(notepad.note.val());
 		}
 
-		if ((event.ctrlKey && event.code === 'Delete') || (event.metaKey && event.code === 'Backspace')) {
+		if ((event.ctrlKey && event.shiftKey && event.code === 'Delete') || (event.metaKey && event.code === 'Backspace')) {
 			event.preventDefault();
 			deleteNotes();
 		}


### PR DESCRIPTION
### Summary

This PR restores the default `Ctrl + Delete` behavior for deleting the next word by moving the "Clear Note" action to `Ctrl + Shift + Delete`.

### Changes
- Changed the clear-note shortcut from `Ctrl + Delete` to `Ctrl + Shift + Delete`
- Preserved the existing clear-note functionality
- Restored standard text-editing behavior for `Ctrl + Delete`
- Updated the keyboard shortcuts modal
- Adjusted the modal layout to accommodate the longer shortcut

Fixes #62